### PR TITLE
Add bond add google_auth Command with Multi-Flavor Google Sign-In Support

### DIFF
--- a/lib/commands/add_command.dart
+++ b/lib/commands/add_command.dart
@@ -1,0 +1,15 @@
+import 'package:args/command_runner.dart';
+
+import 'auth/google_auth/add_google_auth_command.dart';
+
+class AddCommand extends Command {
+  @override
+  String get description => 'Add new integrations to your Flutter Bond app.';
+
+  @override
+  String get name => 'add';
+
+  AddCommand() {
+    addSubcommand(AddGoogleAuthCommand());
+  }
+}

--- a/lib/commands/auth/google_auth/add_google_auth_command.dart
+++ b/lib/commands/auth/google_auth/add_google_auth_command.dart
@@ -1,0 +1,27 @@
+import 'package:args/command_runner.dart';
+import 'package:bond_cli/core/tasks/auth/add_google_auth_task.dart';
+import 'package:bond_cli/core/tasks/auth/google/check_firebase_integration_task.dart';
+import 'package:native_project_manipulator/util/console.dart';
+
+class AddGoogleAuthCommand extends Command {
+  @override
+  String get name => 'google_auth';
+
+  @override
+  String get description =>
+      'Automates the process of adding Google Sign-In to a Flutter app.';
+
+  AddGoogleAuthCommand();
+
+  @override
+  void run() async {
+    final firebaseIntegrated = await CheckFirebaseIntegrationTask().execute();
+    if (!firebaseIntegrated) {
+      printError(
+        'Firebase is not integrated. Please integrate Firebase first.',
+      );
+      return;
+    }
+    await AddGoogleAuthTask().run();
+  }
+}

--- a/lib/commands/bond_command_runner.dart
+++ b/lib/commands/bond_command_runner.dart
@@ -1,4 +1,5 @@
 import 'package:args/command_runner.dart';
+import 'package:bond_cli/commands/add_command.dart';
 import 'package:bond_cli/commands/create_command.dart';
 
 import 'update_command.dart';
@@ -11,5 +12,6 @@ class BondCommandRunner extends CommandRunner<void> {
         ) {
     addCommand(CreateCommand());
     addCommand(UpdateCommand());
+    addCommand(AddCommand());
   }
 }

--- a/lib/config/google_auth.dart
+++ b/lib/config/google_auth.dart
@@ -1,0 +1,14 @@
+/// Google Auth Configurations
+///
+/// To get the values of the keys below:
+/// 1. CLIENT_ID: Go to the Google Developer Console, create a new project or select an existing one,
+///    then navigate to "APIs & Services" > "Credentials" and create an OAuth 2.0 Client ID for iOS.
+/// 2. SCOPES: Define the scopes your app needs access to. Example: "email, profile".
+/// 3. SERVER_CLIENT_ID: If you need to authenticate to a backend server, create a new Web Application
+///    OAuth 2.0 Client ID and use its client ID value.
+
+const googleAuthConfigs = {
+  'CLIENT_ID': String.fromEnvironment('CLIENT_ID'),
+  'SCOPES': String.fromEnvironment('SCOPES'),
+  'SERVER_CLIENT_ID': String.fromEnvironment('SERVER_CLIENT_ID'),
+};

--- a/lib/core/tasks/auth/add_google_auth_task.dart
+++ b/lib/core/tasks/auth/add_google_auth_task.dart
@@ -1,0 +1,22 @@
+import 'package:bond_cli/core/tasks/core/task.dart';
+import 'package:bond_cli/core/tasks/core/tasks.dart';
+
+import 'google/add_dependency_to_pubspec_task.dart';
+import 'google/create_configuration_file_task.dart';
+import 'google/integrate_ios_task.dart';
+import 'google/update_configs_file_task.dart';
+import 'google/update_environment_files_task.dart';
+
+class AddGoogleAuthTask extends Tasks {
+  @override
+  String get actionDescription => 'Automate Google Sign-In integration.';
+
+  @override
+  List<Task> get tasks => [
+        IntegrateIosTask(),
+        AddDependencyToPubspecTask(),
+        UpdateEnvironmentFilesTask(),
+        CreateConfigurationFileTask(),
+        UpdateConfigsFileTask(),
+      ];
+}

--- a/lib/core/tasks/auth/google/add_dependency_to_pubspec_task.dart
+++ b/lib/core/tasks/auth/google/add_dependency_to_pubspec_task.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:bond_cli/core/tasks/core/task.dart';
+
+class AddDependencyToPubspecTask extends Task {
+  @override
+  String get actionDescription =>
+      'Add google_sign_in dependency to pubspec.yaml.';
+
+  @override
+  Future<void> execute() async {
+    final pubspecPath = 'pubspec.yaml';
+    final pubspecFile = File(pubspecPath);
+
+    if (!pubspecFile.existsSync()) {
+      print('Error: pubspec.yaml not found.');
+      return;
+    }
+
+    final content = pubspecFile.readAsStringSync();
+    if (!content.contains('google_sign_in:')) {
+      final updatedContent = content.replaceFirst(
+        'dependencies:',
+        'dependencies:\n  google_sign_in: ^6.2.1',
+      );
+      pubspecFile.writeAsStringSync(updatedContent);
+      print('google_sign_in dependency has been added to pubspec.yaml.');
+    } else {
+      print('google_sign_in dependency already exists in pubspec.yaml.');
+    }
+  }
+}

--- a/lib/core/tasks/auth/google/check_firebase_integration_task.dart
+++ b/lib/core/tasks/auth/google/check_firebase_integration_task.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:bond_cli/core/tasks/core/task.dart';
+
+class CheckFirebaseIntegrationTask extends Task<bool> {
+  @override
+  String get actionDescription => 'Check Firebase integration.';
+
+  @override
+  Future<bool> execute() async {
+    final androidPaths = [
+      'android/app/google-services.json',
+      'android/app/src/production/google-services.json',
+      'android/app/src/staging/google-services.json',
+    ];
+
+    final iosPaths = [
+      'ios/Runner/GoogleService-Info.plist',
+      'ios/Runner/production/GoogleService-Info.plist',
+      'ios/Runner/staging/GoogleService-Info.plist',
+    ];
+
+    final androidIntegrated =
+        androidPaths.any((path) => File(path).existsSync());
+    final iosIntegrated = iosPaths.any((path) => File(path).existsSync());
+
+    return androidIntegrated && iosIntegrated;
+  }
+}

--- a/lib/core/tasks/auth/google/create_configuration_file_task.dart
+++ b/lib/core/tasks/auth/google/create_configuration_file_task.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:bond_cli/core/tasks/core/task.dart';
+
+class CreateConfigurationFileTask extends Task {
+  @override
+  String get actionDescription => 'Create google_auth.dart configuration file.';
+
+  @override
+  Future<void> execute() async {
+    final configPath = 'lib/config/google_auth.dart';
+    final configFile = File(configPath);
+    final content = '''
+/// Google Auth Configurations
+///
+/// ------------------------------------------------------------------------
+/// Google Sign-In Configuration
+/// ------------------------------------------------------------------------
+///
+/// In order to access Google services, the application needs to be authenticated
+/// using OAuth 2.0. This involves providing a Client ID, Scopes, and optionally a
+/// Server Client ID if backend authentication is required.
+///
+/// For detailed instructions on setting up Google Sign-In, refer to the official
+/// documentation at:
+///
+/// https://developers.google.com/identity
+///
+/// Ensure that these variables are set in your environment configuration files
+/// (env.json, env.staging.json) as shown below:
+///
+/// ------------------------------------------------------------------------
+
+const googleAuthConfigs = {
+  /// ------------------------------------------------------------------------
+  /// GOOGLE_CLIENT_ID
+  /// ------------------------------------------------------------------------
+  ///
+  /// The OAuth client ID for your app. This is required.
+  ///
+  /// To obtain this:
+  /// 1. Go to the Google Developer Console.
+  /// 2. Create a new project or select an existing one.
+  /// 3. Navigate to "APIs & Services" > "Credentials".
+  /// 4. Create an OAuth 2.0 Client ID for Web Application.
+  ///
+  'GOOGLE_CLIENT_ID': String.fromEnvironment('GOOGLE_CLIENT_ID'),
+
+  /// ------------------------------------------------------------------------
+  /// GOOGLE_SCOPES
+  /// ------------------------------------------------------------------------
+  ///
+  /// The scopes required by your app. Example: "email, profile".
+  ///
+  /// Define the scopes your app needs access to, which might include:
+  /// - email
+  /// - profile
+  ///
+  'GOOGLE_SCOPES': String.fromEnvironment('GOOGLE_SCOPES'),
+
+  /// ------------------------------------------------------------------------
+  /// GOOGLE_SERVER_CLIENT_ID
+  /// ------------------------------------------------------------------------
+  ///
+  /// The OAuth client ID for your backend server. This is optional.
+  ///
+  /// To obtain this:
+  /// 1. Go to the Google Developer Console.
+  /// 2. Create a new project or select an existing one.
+  /// 3. Navigate to "APIs & Services" > "Credentials".
+  /// 4. Create an OAuth 2.0 Client ID for Web Application.
+  ///
+  'GOOGLE_SERVER_CLIENT_ID': String.fromEnvironment('GOOGLE_SERVER_CLIENT_ID'),
+
+  /// ------------------------------------------------------------------------
+  /// GOOGLE_REVERSED_CLIENT_ID
+  /// ------------------------------------------------------------------------
+  ///
+  /// The reversed client ID for your app, used for URL schemes.
+  ///
+  /// This value is typically found in the GoogleService-Info.plist file.
+  ///
+  'GOOGLE_REVERSED_CLIENT_ID': String.fromEnvironment('GOOGLE_REVERSED_CLIENT_ID'),
+};
+''';
+
+    if (!configFile.existsSync()) {
+      configFile.createSync(recursive: true);
+      configFile.writeAsStringSync(content);
+    } else {
+      print('google_auth.dart configuration file already exists.');
+    }
+  }
+}

--- a/lib/core/tasks/auth/google/integrate_ios_task.dart
+++ b/lib/core/tasks/auth/google/integrate_ios_task.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:bond_cli/core/tasks/core/task.dart';
+
+class IntegrateIosTask extends Task {
+  @override
+  String get actionDescription => 'Integrate Google Sign-In for iOS.';
+
+  @override
+  Future<void> execute() async {
+    final iosPaths = ['ios/Runner/Info.plist'];
+
+    for (var path in iosPaths) {
+      final infoPlistFile = File(path);
+      if (infoPlistFile.existsSync()) {
+        var content = await infoPlistFile.readAsString();
+        final googleSignInConfig = '''
+<!-- Google Sign-in Section -->
+<key>GIDClientID</key>
+<string>\${GOOGLE_CLIENT_ID}</string>
+<key>GIDServerClientID</key>
+<string>\${GOOGLE_SERVER_CLIENT_ID}</string>
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>\${GOOGLE_REVERSED_CLIENT_ID}</string>
+    </array>
+  </dict>
+</array>
+<!-- End of the Google Sign-in Section -->
+''';
+
+        if (!content.contains('<key>GIDClientID</key>')) {
+          content = content.replaceFirst(
+              '</dict>\n</plist>', '$googleSignInConfig\n</dict>\n</plist>');
+          await infoPlistFile.writeAsString(content);
+        } else {
+          print(
+              'Info.plist at $path already contains Google Sign-In configuration.');
+        }
+      }
+    }
+  }
+}

--- a/lib/core/tasks/auth/google/update_configs_file_task.dart
+++ b/lib/core/tasks/auth/google/update_configs_file_task.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:bond_cli/core/tasks/core/task.dart';
+
+class UpdateConfigsFileTask extends Task {
+  UpdateConfigsFileTask();
+
+  @override
+  String get actionDescription => 'Update configs.dart file with new configs.';
+
+  @override
+  Future<void> execute() async {
+    // Update configs.dart file
+    final configsFilePath = 'lib/config/configs.dart';
+    final configsFile = File(configsFilePath);
+    if (configsFile.existsSync()) {
+      var configsContent = await configsFile.readAsString();
+
+      // Add the import statement if it doesn't exist
+      if (!configsContent.contains("import 'google_auth.dart';")) {
+        configsContent = "import 'google_auth.dart';\n$configsContent";
+      }
+      if (!configsContent.contains('...googleAuthConfigs')) {
+        configsContent = configsContent.replaceFirst(
+          'final configs = {',
+          'final configs = {\n  ...googleAuthConfigs,',
+        );
+        await configsFile.writeAsString(configsContent);
+      } else {
+        print('configs.dart already contains googleAuthConfigs.');
+      }
+    } else {
+      throw 'Error: configs.dart not found.';
+    }
+  }
+}

--- a/lib/core/tasks/auth/google/update_environment_files_task.dart
+++ b/lib/core/tasks/auth/google/update_environment_files_task.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bond_cli/core/tasks/core/task.dart';
+
+class UpdateEnvironmentFilesTask extends Task {
+  @override
+  String get actionDescription =>
+      'Update env.json and env.staging.json with Google Sign-In variables.';
+
+  @override
+  Future<void> execute() async {
+    final envFiles = ['env.json', 'env.staging.json'];
+    final Map<String, String> variables = {
+      'GOOGLE_CLIENT_ID': 'Your-Google-Client-ID',
+      'GOOGLE_SCOPES': 'email,profile',
+      'GOOGLE_SERVER_CLIENT_ID': 'Your-Google-Server-Client-ID',
+      'GOOGLE_REVERSED_CLIENT_ID':
+          'com.googleusercontent.apps.your-reversed-client-id'
+    };
+
+    for (var filePath in envFiles) {
+      final file = File(filePath);
+      if (file.existsSync()) {
+        final content =
+            json.decode(await file.readAsString()) as Map<String, dynamic>;
+        content.addAll(variables);
+        final encoder = JsonEncoder.withIndent('  ');
+        final formattedContent = encoder.convert(content);
+        await file.writeAsString(formattedContent);
+        print('$filePath has been updated with Google Sign-In variables.');
+      } else {
+        throw Exception('Error: $filePath not found.');
+      }
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: dart_internal
-      sha256: dae3976f383beddcfcd07ad5291a422df2c8c0a8a03c52cda63ac7b4f26e0f4e
+      sha256: "17ad5e3da43df562bb98ca0d88e9f32aeb16c97ec33dee822b21c3b2d0875726"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.12"
   ffi:
     dependency: transitive
     description:
@@ -474,4 +474,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.0.3 <3.2.0"
+  dart: ">=3.0.3 <3.6.0"


### PR DESCRIPTION

**Overview:**
This pull request introduces a new command `bond add google_auth` to the Bond CLI, which automates the integration of Google Sign-In into a Flutter app. The implementation supports multiple environments and flavors (production and staging).

**Changes:**
1. **Tasks Implementation:**
   - `CreateConfigurationFileTask`: Generates `google_auth.dart` with required environment variables.
   - `UpdateEnvironmentFilesTask`: Adds Google Sign-In variables to `env.json` and `env.staging.json`.
   - `UpdateConfigsFileTask`: Updates `configs.dart` to include `googleAuthConfigs`.

2. **Environment Configuration:**
   - Added `GOOGLE_CLIENT_ID`, `GOOGLE_SCOPES`, `GOOGLE_SERVER_CLIENT_ID`, and `GOOGLE_REVERSED_CLIENT_ID` variables.
   - Detailed comments and instructions for each variable.

